### PR TITLE
Bump references and provide extensions for easy service registration

### DIFF
--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 1,
-  "Minor": 3,
+  "Minor": 4,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/src/Jaahas.Extensions.Logging.CommonLogging.MicrosoftAdapter/CommonLoggingExtensions.cs
+++ b/src/Jaahas.Extensions.Logging.CommonLogging.MicrosoftAdapter/CommonLoggingExtensions.cs
@@ -1,0 +1,64 @@
+﻿using System;
+
+using Jaahas.CommonLogging.MicrosoftAdapter;
+
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Extensions.DependencyInjection {
+
+    /// <summary>
+    /// Extensions for registering and using <c>Common.Logging</c> with <see cref="IServiceCollection"/> 
+    /// and <see cref="IServiceProvider"/>.
+    /// </summary>
+    public static class CommonLoggingExtensions {
+
+        /// <summary>
+        /// Registers a singleton <see cref="Common.Logging.ILoggerFactoryAdapter"/> service that 
+        /// uses <see cref="MicrosoftLoggerFactoryAdapter"/> as its implementation type.
+        /// </summary>
+        /// <param name="services">
+        ///   The <see cref="IServiceCollection"/>.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="IServiceCollection"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="services"/> is <see langword="null"/>.
+        /// </exception>
+        public static IServiceCollection AddMicrosoftCommonLoggingAdapter(this IServiceCollection services) {
+            if (services == null) {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.TryAddSingleton<MicrosoftLoggerFactoryAdapter>();
+            services.TryAddSingleton<Common.Logging.ILogManager, Common.Logging.LogManager>();
+
+            return services;
+        }
+
+
+        /// <summary>
+        /// Configures the static <see cref="Common.Logging.LogManager.Adapter"/> property to use 
+        /// the registered <see cref="MicrosoftLoggerFactoryAdapter"/>.
+        /// </summary>
+        /// <param name="provider">
+        ///   The <see cref="IServiceProvider"/>.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="IServiceProvider"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="provider"/> is <see langword="null"/>.
+        /// </exception>
+        public static IServiceProvider UseMicrosoftCommonLoggingAdapter(this IServiceProvider provider) {
+            if (provider == null) {
+                throw new ArgumentNullException(nameof(provider));
+            }
+
+            var adapter = provider.GetRequiredService<MicrosoftLoggerFactoryAdapter>();
+            Common.Logging.LogManager.Adapter = adapter;
+            return provider;
+        }
+
+    }
+}

--- a/src/Jaahas.Extensions.Logging.CommonLogging.MicrosoftAdapter/Jaahas.Extensions.Logging.CommonLogging.MicrosoftAdapter.csproj
+++ b/src/Jaahas.Extensions.Logging.CommonLogging.MicrosoftAdapter/Jaahas.Extensions.Logging.CommonLogging.MicrosoftAdapter.csproj
@@ -3,11 +3,16 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Allows Common.Logging to write messages to Microsoft.Extensions.Logging.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="README.md" Pack="true" />
   </ItemGroup>
 
 </Project>

--- a/src/Jaahas.Extensions.Logging.CommonLogging.MicrosoftAdapter/README.md
+++ b/src/Jaahas.Extensions.Logging.CommonLogging.MicrosoftAdapter/README.md
@@ -1,5 +1,29 @@
-﻿# Jaahas.Extensions.Logging.CommonLogging.MicrosoftAdapter
+﻿# About
 
-[Common.Logging](https://github.com/net-commons/common-logging) adapter that logs to [Microsoft.Extensions.Logging](https://github.com/aspnet/Extensions/tree/master/src/Logging).
+Jaahas.Extensions.Logging.CommonLogging.MicrosoftAdapter is a [Common.Logging](https://github.com/net-commons/common-logging) `ILoggerFactoryAdapter` that allows Common.Logging to write messages to `Microsoft.Extensions.Logging.ILogger` instances.
 
-This allows you to wire up logging from libraries that use `Common.Logging` to e.g. ASP.NET Core applications.
+This allows e.g. legacy ASP.NET applications that use Common.Logging to hook into the modern .NET logging infrastructure without requiring a rewrite of logging code.
+
+
+# Getting Started
+
+Register the Microsoft.Extensions.Logging adapter for Common.Logging when configuring your dependency injection container and then configure the static `Common.Logging.LogManager` class to use the adapter:
+
+```csharp
+var builder = Host.CreateDefaultBuilder()
+    .ConfigureServices((context, services) => {
+        services.AddMicrosoftCommonLoggingAdapter();
+    });
+
+var app = builder.Build();
+
+app.Services.UseMicrosoftCommonLoggingAdapter();
+```
+
+You can also request the `Common.Logging.ILogManager` service from the dependency injection container to get a log manager instance instead of calling static members on `Common.Logging.LogManager`:
+
+```csharp
+var logManager = app.Services.GetRequiredService<Common.Logging.ILogManager>();
+```
+
+Log manager instances retrieved in this way will use the Microsoft.Extensions.Logging adapter as long as the `UseMicrosoftCommonLoggingAdapter` extension is called after the service provider has been built.

--- a/src/Jaahas.Extensions.Logging.CommonLogging/CommonLoggingLogger.cs
+++ b/src/Jaahas.Extensions.Logging.CommonLogging/CommonLoggingLogger.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 
 using Common.Logging;
+
 using Microsoft.Extensions.Logging;
 
 namespace Jaahas.Extensions.Logging.CommonLogging {

--- a/src/Jaahas.Extensions.Logging.CommonLogging/CommonLoggingLoggerFactory.cs
+++ b/src/Jaahas.Extensions.Logging.CommonLogging/CommonLoggingLoggerFactory.cs
@@ -1,63 +1,81 @@
 ﻿using System;
+
 using Microsoft.Extensions.Logging;
 
 namespace Jaahas.Extensions.Logging.CommonLogging {
+
+    /// <summary>
+    /// <see cref="ILoggerFactory"/> implementation that uses <c>Common.Logging</c> for logging.
+    /// </summary>
     public class CommonLoggingLoggerFactory : ILoggerFactory {
 
-        private bool _isDisposed;
+        /// <summary>
+        /// Specifies whether the object has been disposed.
+        /// </summary>
+        private bool _disposed;
 
+        /// <summary>
+        /// The <see cref="CommonLoggingLoggerProvider"/> instance to use.
+        /// </summary>
         private readonly CommonLoggingLoggerProvider _provider;
 
-        private static readonly Lazy<CommonLoggingLoggerFactory> _default = new Lazy<CommonLoggingLoggerFactory>(() => new CommonLoggingLoggerFactory(), System.Threading.LazyThreadSafetyMode.ExecutionAndPublication);
+        /// <summary>
+        /// The default <see cref="CommonLoggingLoggerFactory"/> instance.
+        /// </summary>
+        private static readonly Lazy<CommonLoggingLoggerFactory> s_default = new Lazy<CommonLoggingLoggerFactory>(() => new CommonLoggingLoggerFactory(), System.Threading.LazyThreadSafetyMode.ExecutionAndPublication);
 
-        public static CommonLoggingLoggerFactory Default { get { return _default.Value; } }
+        /// <summary>
+        /// The default <see cref="CommonLoggingLoggerFactory"/> instance.
+        /// </summary>
+        public static CommonLoggingLoggerFactory Default { get { return s_default.Value; } }
 
 
+        /// <summary>
+        /// Creates a new <see cref="CommonLoggingLoggerFactory"/> instance using a default 
+        /// <see cref="CommonLoggingLoggerProvider"/> instance.
+        /// </summary>
         public CommonLoggingLoggerFactory() : this(null) { }
 
 
+        /// <summary>
+        /// Creates a new <see cref="CommonLoggingLoggerFactory"/> instance using the specified 
+        /// <see cref="CommonLoggingLoggerProvider"/> instance.
+        /// </summary>
+        /// <param name="provider">
+        ///   The <see cref="CommonLoggingLoggerProvider"/> instance to use. Specify <see langword="null"/> 
+        ///   to create a new provider.
+        /// </param>
         public CommonLoggingLoggerFactory(CommonLoggingLoggerProvider provider) {
             _provider = provider ?? new CommonLoggingLoggerProvider(new Common.Logging.LogManager(), new LoggerExternalScopeProvider());
         }
 
 
+        /// <inheritdoc/>
         public ILogger CreateLogger(string categoryName) {
-            if (_isDisposed) {
+            if (_disposed) {
                 throw new ObjectDisposedException(GetType().FullName);
             }
 
             return _provider.CreateLogger(categoryName);
         }
 
-        public void AddProvider(ILoggerProvider provider) {
-            if (_isDisposed) {
-                throw new ObjectDisposedException(GetType().FullName);
-            }
 
+        /// <inheritdoc/>
+        public void AddProvider(ILoggerProvider provider) {
             // Do nothing.
         }
 
 
-        private void Dispose(bool disposing) {
-            if (disposing) {
-                _provider.Dispose();
-            }
-        }
-
-
+        /// <inheritdoc/>
         public void Dispose() {
-            if (_isDisposed) {
+            if (_disposed) {
                 return;
             }
 
-            Dispose(true);
-            _isDisposed = true;
+            _provider.Dispose();
+
+            _disposed = true;
             GC.SuppressFinalize(this);
-        }
-
-
-        ~CommonLoggingLoggerFactory() {
-            Dispose(false);
         }
 
     }

--- a/src/Jaahas.Extensions.Logging.CommonLogging/CommonLoggingLoggerProvider.cs
+++ b/src/Jaahas.Extensions.Logging.CommonLogging/CommonLoggingLoggerProvider.cs
@@ -1,25 +1,50 @@
 ﻿using Microsoft.Extensions.Logging;
 
 namespace Jaahas.Extensions.Logging.CommonLogging {
+
+    /// <summary>
+    /// <see cref="ILoggerProvider"/> implementation that creates <see cref="CommonLoggingLogger"/> 
+    /// instances.
+    /// </summary>
     public class CommonLoggingLoggerProvider : ILoggerProvider {
 
+        /// <summary>
+        /// The Common.Logging log manager.
+        /// </summary>
         private readonly Common.Logging.ILogManager _logManager;
 
+        /// <summary>
+        /// The external scope provider for the logger provider.
+        /// </summary>
         private readonly IExternalScopeProvider _scopeProvider;
 
 
+        /// <summary>
+        /// Creates a new <see cref="CommonLoggingLoggerProvider"/> instance.
+        /// </summary>
+        /// <param name="logManager">
+        ///   The Common.Logging log manager to use. Specify <see langword="null"/> to use a new 
+        ///   <see cref="Common.Logging.LogManager"/> instance.
+        /// </param>
+        /// <param name="scopeProvider">
+        ///   The <see cref="IExternalScopeProvider"/> to use.
+        /// </param>
         public CommonLoggingLoggerProvider(Common.Logging.ILogManager logManager, IExternalScopeProvider scopeProvider = null) {
             _logManager = logManager ?? new Common.Logging.LogManager();
             _scopeProvider = scopeProvider;
         }
 
 
+        /// <inheritdoc/>
         public ILogger CreateLogger(string categoryName) {
             return new CommonLoggingLogger(_logManager.GetLogger(categoryName), _scopeProvider);
         }
 
+
+        /// <inheritdoc/>
         public void Dispose() {
             // Do nothing.
         }
+
     }
 }

--- a/src/Jaahas.Extensions.Logging.CommonLogging/CommonLoggingLoggingBuilderExtensions.cs
+++ b/src/Jaahas.Extensions.Logging.CommonLogging/CommonLoggingLoggingBuilderExtensions.cs
@@ -1,0 +1,83 @@
+﻿using System;
+
+using Jaahas.Extensions.Logging.CommonLogging;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Extensions.Logging {
+
+    /// <summary>
+    /// Extensions for registering <c>Common.Logging</c> with the <see cref="ILoggingBuilder"/>.
+    /// </summary>
+    public static class CommonLoggingLoggingBuilderExtensions {
+
+        /// <summary>
+        /// Adds a <c>Common.Logging</c> logger provider.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="ILoggingBuilder"/>.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="ILoggingBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggingBuilder AddCommonLogging(this ILoggingBuilder builder) {
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Services.TryAddSingleton<Common.Logging.ILogManager, Common.Logging.LogManager>();
+            builder.AddCommonLoggingLoggerProvider();
+
+            return builder;
+        }
+
+
+        /// <summary>
+        /// Adds a <c>Common.Logging</c> logger provider.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="ILoggingBuilder"/>.
+        /// </param>
+        /// <param name="logManager">
+        ///   The <see cref="Common.Logging.ILogManager"/> to use when creating loggers.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="ILoggingBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="logManager"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggingBuilder AddCommonLogging(this ILoggingBuilder builder, Common.Logging.ILogManager logManager) {
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (logManager == null) {
+                throw new ArgumentNullException(nameof(logManager));
+            }
+
+            builder.Services.TryAddSingleton(logManager);
+            builder.AddCommonLoggingLoggerProvider();
+
+            return builder;
+        }
+
+
+        /// <summary>
+        /// Registers <see cref="CommonLoggingLoggerProvider"/> with the <see cref="ILoggingBuilder"/>.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="ILoggingBuilder"/>.
+        /// </param>
+        private static void AddCommonLoggingLoggerProvider(this ILoggingBuilder builder) {
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider>(provider => ActivatorUtilities.CreateInstance<CommonLoggingLoggerProvider>(provider, provider.GetService<IExternalScopeProvider>() ?? new LoggerExternalScopeProvider())));
+        }
+
+    }
+}

--- a/src/Jaahas.Extensions.Logging.CommonLogging/Jaahas.Extensions.Logging.CommonLogging.csproj
+++ b/src/Jaahas.Extensions.Logging.CommonLogging/Jaahas.Extensions.Logging.CommonLogging.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <Description>Allows Microsoft.Extensions.Logging to write log messages to Common.Logging.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <!-- Different Common.Logging minimum version required for .NET Standard 2.0 compatibility. -->
@@ -22,7 +23,11 @@
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="$(CommonLoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="README.md" Pack="true" />
   </ItemGroup>
 
 </Project>

--- a/src/Jaahas.Extensions.Logging.CommonLogging/README.md
+++ b/src/Jaahas.Extensions.Logging.CommonLogging/README.md
@@ -1,5 +1,21 @@
-﻿# Jaahas.Logging.Extensions.CommonLogging
+﻿# About
 
-[Microsoft.Extensions.Logging](https://github.com/aspnet/Extensions/tree/master/src/Logging) implementation that logs to [Common.Logging](https://github.com/net-commons/common-logging).
+Jaahas.Extensions.Logging.CommonLogging is a `Microsoft.Extensions.Logging.ILoggerProvider` implementation that writes log messages to [Common.Logging](https://github.com/net-commons/common-logging).
 
-This allows you to integrate libraries that use `Microsoft.Extensions.Logging` into existing applications that use `Common.Logging`.
+This allows libraries and components that write log messages using modern .NET logging infrastructure to be consumed by legacy applications that use Common.Logging without requiring a rewrite of logging code.
+
+
+# Getting Started
+
+Add the Common.Logging provider to your logger configuration when building your dependency injection container:
+
+```csharp
+services.AddLogging(logging => {
+    // Remove the default logging providers and add Common.Logging instead
+    logging.ClearProviders().AddCommonLogging();
+});
+```
+
+Refer to the [Common.Logging documentation](https://github.com/net-commons/common-logging) for information on how to configure Common.Logging to log to your destination(s) of choice.
+
+


### PR DESCRIPTION
This PR pumps `System.Text.Json` to version 8.0.4 to mitigate CVE-2024-30105.

It also ensures that both libraries reference Microsoft.Extensions.Logging.Abstractions 8.0.1 and adds extension methods to assist with registering dependency injection services. 